### PR TITLE
Fixed cobble gen voiding items inserted into it

### DIFF
--- a/src/main/java/net/minecraftforge/lex/cfd/CobbleGenTile.java
+++ b/src/main/java/net/minecraftforge/lex/cfd/CobbleGenTile.java
@@ -194,7 +194,7 @@ public class CobbleGenTile extends TileEntity implements ITickableTileEntity {
 
         @Override
         public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
-            return ItemStack.EMPTY;
+            return stack;
         }
 
         @Override


### PR DESCRIPTION
If you want to test current behavior, put a hopper with dirt on top of it. Dirt will get completely voided.